### PR TITLE
Make Bubble pop smoother

### DIFF
--- a/src/lib/components/bubbles/Bubble.svelte
+++ b/src/lib/components/bubbles/Bubble.svelte
@@ -15,7 +15,7 @@
 			duration: options.duration || 200,
 			delay: options.delay || 0,
 
-			css: (t, u) => `transform: scale(${u + 1}); opacity: ${t * opacity}`
+			css: (t, u) => `transform: scale3d(${u + 1}, ${u + 1}, ${u + 1}); opacity: ${t * opacity}`
 		};
 	};
 


### PR DESCRIPTION
Bubble pop rt now on a slow machine(mine) stops all the bubbles in their places for a while. Basically it locks up main thread heavily. 

I changed `scale` -> `scale3d`. Now it is perfectly smooth.