### PR TITLE
refactor: :recycle: fix lint warnings for noreferrer

### DIFF
--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -40,7 +40,7 @@
 		</p>
 		<a
 			class="btn-primary"
-			rel="noopener noreffer"
+			rel="noopener noreferrer"
 			target="_blank"
 			href="https://discord.gg/4TVdc4RRps"
 		>
@@ -53,7 +53,7 @@
 	<section class="glass grid content">
 		<p>
 			The original idea for the Svelte Sirens came from
-			<a rel="noopener noreffer" target="_blank" href="https://www.swyx.io/">
+			<a rel="noopener noreferrer" target="_blank" href="https://www.swyx.io/">
 				Shawn Wang (aka Swyx)
 			</a>
 			realizing there was a need to support the women and non-binary people inside the Svelte community
@@ -61,13 +61,13 @@
 			<a href="/speakers/brittney-postma">Brittney Postma</a>, a Developer Experience Engineer at Netlify, stepped up to found the Svelte Sirens.
 			in September of 2021, designing and working on the site while reaching out to others to join.
 			<a href="/speakers/ghost">Willow</a>, who also does open source with
-			<a rel="noopener noreffer" target="_blank" href="https://www.routify.dev/">Routify</a>, came
+			<a rel="noopener noreferrer" target="_blank" href="https://www.routify.dev/">Routify</a>, came
 			on to help soon after the group was formed.
 			<a href="/speakers/steph-dietz">Steph Dietz</a>
 			is a dev rel at Vercel for Svelte and wants to be more involved with the Svelte community.
 			 The 3 of us organize all of the
 			<a href="/upcoming">Events</a>, help out in the
-			<a rel="noopener noreffer" target="_blank" href="https://discord.gg/4TVdc4RRps">Discord</a>,
+			<a rel="noopener noreferrer" target="_blank" href="https://discord.gg/4TVdc4RRps">Discord</a>,
 			and support all of the women and non-binary people in the Svelte community. Please reach out
 			to any of us directly or email
 			<a href="mailto:sveltesirens@gmail.com">SvelteSirens@gmail.com</a> if you ever encounter a

--- a/src/routes/latest/+page.svelte
+++ b/src/routes/latest/+page.svelte
@@ -30,7 +30,7 @@
 								<a href="/speakers/{slug}">{name}</a>
 							</p>
 							<div class="lg">
-								<a href={handleUrl} rel="noopener norefferer" target="_blank">
+								<a href={handleUrl} rel="noopener noreferrer" target="_blank">
 									<span>{handle}</span>
 								</a>
 							</div>
@@ -44,7 +44,7 @@
 								<a href="/speakers/{slug}">{name}</a>
 							</p>
 							<div class="lg">
-								<a href={handleUrl} rel="noopener norefferer" target="_blank">
+								<a href={handleUrl} rel="noopener noreferrer" target="_blank">
 									<span>{handle}</span>
 								</a>
 							</div>
@@ -79,7 +79,7 @@
 							Svelte Society YouTube
 						</a>
 						and
-						<a rel="noopener noreffer" target="_blank" href="https://discord.gg/4TVdc4RRps">
+						<a rel="noopener noreferrer" target="_blank" href="https://discord.gg/4TVdc4RRps">
 							Svelte Discord
 						</a> to chat with the community.
 					</div>

--- a/src/routes/speakers/[slug]/+page.svelte
+++ b/src/routes/speakers/[slug]/+page.svelte
@@ -6,7 +6,7 @@
 <article class="glass">
 	<h1>{data.speaker.name}</h1>
 	<img src={data.speaker.picture} alt={data.speaker.name} class="speaker" />
-	<a href={data.speaker.handleUrl} rel="noopener norefferer" target="_blank">
+	<a href={data.speaker.handleUrl} rel="noopener noreferrer" target="_blank">
 		<span>{data.speaker.handle}</span>
 	</a>
 

--- a/src/routes/upcoming/+page.svelte
+++ b/src/routes/upcoming/+page.svelte
@@ -37,7 +37,7 @@
 					</p>
 
 					<div class="lg">
-						<a href={handleUrl} rel="noopener norefferer" target="_blank">
+						<a href={handleUrl} rel="noopener noreferrer" target="_blank">
 							<span>{handle}</span>
 						</a>
 					</div>
@@ -53,7 +53,7 @@
 						</p>
 
 						<div class="lg">
-							<a href={handleUrl} rel="noopener norefferer" target="_blank">
+							<a href={handleUrl} rel="noopener noreferrer" target="_blank">
 								<span>{handle}</span>
 							</a>
 						</div>
@@ -80,7 +80,7 @@
 						Svelte Society YouTube
 					</a>
 					and
-					<a rel="noopener noreffer" target="_blank" href="https://discord.gg/4TVdc4RRps">
+					<a rel="noopener noreferrer" target="_blank" href="https://discord.gg/4TVdc4RRps">
 						Svelte Discord
 					</a> to chat with the community.
 				</div>


### PR DESCRIPTION
Hey, small change for lint warnings for `noreferrer`

There's still a warning for `Bubble.svelte` as it needs and accompanying event:

```
A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.svelte(a11y-click-events-have-key-events)
```

But I'm not sure how to fix that and would appreciate if someone could educate me on the fix here 🙏 